### PR TITLE
remove MODULESGEN during distclean

### DIFF
--- a/configure/RULES_SRC
+++ b/configure/RULES_SRC
@@ -11,7 +11,10 @@ conf: conf.base conf.modules
 
 build: conf.base build.base conf.modules build.modules
 
-distclean: distclean.base distclean.modules
+distclean: distclean.base distclean.modules distclean.modulesgen
+
+distclean.modulesgen:
+	rm -rf $(TOP)/configure/MODULESGEN.mk
 
 null: 
 	@echo ""

--- a/configure/RULES_SRC
+++ b/configure/RULES_SRC
@@ -14,7 +14,7 @@ build: conf.base build.base conf.modules build.modules
 distclean: distclean.base distclean.modules distclean.modulesgen
 
 distclean.modulesgen:
-	rm -rf $(TOP)/configure/MODULESGEN.mk
+	-rm -rf $(TOP)/configure/MODULESGEN.mk
 
 null: 
 	@echo ""


### PR DESCRIPTION
Hi Han,

What do you think about removing generated MODULESGEN.mk file during a distclean? It seemed that I had to do that to get INSTALL_LOCATION_MODS variable change to propagate to all modules. This adds removal to distclean rules.